### PR TITLE
Notify slack channel when the S3 backup fails 

### DIFF
--- a/.github/workflows/s3-backup.yml
+++ b/.github/workflows/s3-backup.yml
@@ -31,3 +31,9 @@ jobs:
     - name: Upload to S3 bucket
       run: |
         aws s3 sync . s3://${{ secrets.AWS_S3_BACKUP_BUCKET }} --exclude='*' --include='${{ github.repository }}/*'
+
+    - name: Notify Slack channel if this job failed
+      if: ${{ failure() }}
+      run: |
+        json="{'text':'<!here> S3 backup failed in <https://github.com/cds-snc/${{ github.repository }}/|${{ github.repository }}> !'}"
+        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_NOTIFY_WEBHOOK }}

--- a/.github/workflows/s3-backup.yml
+++ b/.github/workflows/s3-backup.yml
@@ -35,5 +35,5 @@ jobs:
     - name: Notify Slack channel if this job failed
       if: ${{ failure() }}
       run: |
-        json="{'text':'<!here> S3 backup failed in <https://github.com/cds-snc/${{ github.repository }}/|${{ github.repository }}> !'}"
+        json='{"text":"S3 backup failed in <https://github.com/${{ github.repository }}>!"}'
         curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_NOTIFY_WEBHOOK }}


### PR DESCRIPTION
# Summary | Résumé

Closes [#609](https://github.com/cds-snc/site-reliability-engineering/issues/609)

Added code to notify slack channel (TBD which one, but most likely #internal-sre-alerts) whenever a S3 backup fails.  Added a webhook to notify #Internal-sre-alerts when a backup fails. 