### PR TITLE
fix: add workflow name and update trigger syntax

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,4 +1,8 @@
-on: [issues, pull_request, workflow_dispatch]
+name: Sync repository labels
+on:
+  issues:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   sync-labels:


### PR DESCRIPTION
# Summary
Add a workflow name to the Sync labels workflow.  Also updates the triggers so they can be parsed by tools like `yq`.  There should be no functional difference with this change.

# Related
- https://github.com/cds-snc/cds-superset/pull/221
- https://github.com/cds-snc/platform-core-services/issues/640
