### PR TITLE
fix: add missing workflow permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,8 +1,12 @@
 name: Sync repository labels
+
 on:
   issues:
   pull_request:
   workflow_dispatch:
+
+permissions:
+  issues: write
 
 jobs:
   sync-labels:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,11 +4,14 @@ on:
     paths:
       - "**/*.sh"
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Shellcheck
       run: |
         .github/workflows/scripts/run-shellcheck.sh


### PR DESCRIPTION
# Summary | Résumé
Add a permission block to the workflows to limit the actions that can be taken.
